### PR TITLE
Date format string changed

### DIFF
--- a/src/Command/AddExposedFieldCommand.php
+++ b/src/Command/AddExposedFieldCommand.php
@@ -68,7 +68,7 @@ class AddExposedFieldCommand extends Command {
 
 		$migrationName = $args->getArgument('migration') ?: 'MigrationExposedField' . $prefix . $name;
 		$migrationsPath = CONFIG . 'Migrations' . DS;
-		$migrationFilePath = $migrationsPath . date('YmdH0001') . '_' . $migrationName . '.php';
+		$migrationFilePath = $migrationsPath . date('YmdHis') . '_' . $migrationName . '.php';
 
 		$io->out('Migration to be created: ' . $migrationName);
 		$io->out('File to be created: ' . $migrationFilePath);


### PR DESCRIPTION
Changed the date format string for the migration filename. Otherwise you can only create a new migration file every hour, because trying to migrate migrations with the same timestamp will fail.